### PR TITLE
[small] Feature/010 activityAPI 認可ロジックの実装

### DIFF
--- a/src/main/java/importApp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/importApp/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package importApp.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.nio.file.AccessDeniedException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<String> handleAccessDeniedException(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    }
+}
+

--- a/src/main/java/importApp/security/JwtService.java
+++ b/src/main/java/importApp/security/JwtService.java
@@ -1,7 +1,9 @@
 package importApp.security;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -41,9 +43,17 @@ public class JwtService {
     }
 
     private Claims getClaims(String token) {
-        return Jwts.parser()
-                .setSigningKey(secretKey)
-                .parseClaimsJws(token)
-                .getBody();
+        try {
+            return Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token.replace("Bearer ", ""))
+                    .getBody();
+        } catch (MalformedJwtException e) {
+            throw new IllegalArgumentException("Invalid JWT token format", e);
+        } catch (ExpiredJwtException e) {
+            throw new IllegalArgumentException("JWT token has expired", e);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse JWT token", e);
+        }
     }
 }

--- a/src/main/java/importApp/service/ActivityService.java
+++ b/src/main/java/importApp/service/ActivityService.java
@@ -50,4 +50,14 @@ public class ActivityService {
         int result = activityMapper.markActivityAsDeleted(id);
         return result > 0;
     }
+
+    // アクティビティの所有者確認
+    public boolean isOwner(Long activityId, String userId) {
+        // ユーザーのすべてのアクティビティを取得
+        List<ActivityGetEntity> userActivities = activityMapper.findActivitiesByUserId(Long.parseLong(userId));
+
+        // ユーザーのアクティビティリストに該当するactivityIdが存在するかを確認
+        return userActivities.stream()
+                .anyMatch(activity -> activity.getActivityId().equals(activityId));
+    }
 }


### PR DESCRIPTION
# activityAPI 認可ロジックの実装 - APIのセキュリティ強化

## 概要
- 各APIエンドポイントに認可ロジックを実装しました。
- トークン内のユーザーIDとリクエストのユーザーIDを比較し、不一致の場合に`403 Forbidden`を返します。

## 変更点
1. **認可ロジックの追加**
   - トークンからユーザーIDを抽出。
   - ユーザーIDが一致しない場合に`AccessDeniedException`をスロー。
2. **例外処理の統一**
   - `GlobalExceptionHandler`を実装し、`AccessDeniedException`が発生した際に`403 Forbidden`を返します。
3. **未修正メモ・ファイルアップロードエンドポイントファイルアップロードエンドポイント**
   - 現状、仮のユーザーID（9999）を利用しており、認可ロジックは未導入です。将来的な改修で対応予定。

## テスト
- ポストマンで以下を簡易確認：
  - トークンとリクエスト内のユーザーIDが一致した場合、正常に動作する。
  - ユーザーIDが一致しない場合、`403 Forbidden`が返る。
  - 例外処理が統一されたレスポンスを返す。
