### PR TITLE
[small] Feature/011

### DIFF
--- a/src/main/java/importApp/service/ActivityService.java
+++ b/src/main/java/importApp/service/ActivityService.java
@@ -10,6 +10,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -24,10 +27,12 @@ public class ActivityService {
 
     public String createActivity(PostRequest request) {
         PostActivityEntity entity = modelMapper.map(request, PostActivityEntity.class);
-        entity.setUpdatedAt(null); // 必要に応じて設定
-        entity.setUpdatedBy(null);   // 必要に応じて設定
-        entity.setCreatedAt(null); // 必要に応じて設定
-        entity.setCreatedBy(null);
+        // 作成者と作成日時を設定
+        entity.setCreatedAt(convertToDate(LocalDateTime.now()));
+        entity.setCreatedBy(Long.valueOf(request.getUserId()));
+        // 更新日時と更新者は作成時は未設定
+        entity.setUpdatedAt(null);
+        entity.setUpdatedBy(null);
 
         activityMapper.save(entity);
         return "success";
@@ -35,9 +40,11 @@ public class ActivityService {
 
     public boolean updateActivity(PutRequest request) {
         PostActivityEntity entity = modelMapper.map(request, PostActivityEntity.class);
-        entity.setUpdatedAt(null); // 必要に応じて設定
-        entity.setUpdatedBy(null);   // 必要に応じて設定
-        entity.setCreatedAt(null); // 必要に応じて設定
+        //　更新者と更新日時を設定
+        entity.setUpdatedAt(convertToDate(LocalDateTime.now()));
+        entity.setUpdatedBy(Long.valueOf(request.getUserId()));
+        // 作成日時と作成者は変更しない
+        entity.setCreatedAt(null);
         entity.setCreatedBy(null);
         int updatedRows = activityMapper.updateActivity(entity);
         return updatedRows > 0;
@@ -59,5 +66,10 @@ public class ActivityService {
         // ユーザーのアクティビティリストに該当するactivityIdが存在するかを確認
         return userActivities.stream()
                 .anyMatch(activity -> activity.getActivityId().equals(activityId));
+    }
+
+    // Date型にLocalDateTimeを変換するメソッドの作成
+    private Date convertToDate(LocalDateTime localDateTime) {
+        return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
     }
 }


### PR DESCRIPTION
### 概要
更新・登録時の `created_by`、`created_at`、`updated_by`、`updated_at` フィールドに正しいデータを設定するよう修正。

### 主な変更点
1. **登録処理**:
   - `created_by` にデータ作成者のIDを設定。
   - `created_at` にデータ登録日時を設定。

2. **更新処理**:
   - `updated_by` にデータ更新者のIDを設定。
   - `updated_at` にデータ更新日時を設定。

### 確認済み項目
- 登録時、`created_by` と `created_at` が正しく設定されることを確認。
- 更新時、`updated_by` と `updated_at` が正しく設定されることを確認。
- 既存の登録および更新機能が正常に動作することを確認。



### Summary
Enhanced metadata handling to correctly set `created_by`, `created_at`, `updated_by`, and `updated_at` during data operations.

### Key Changes
1. **Registration Process**:
   - Set `created_by` to the creator's user ID.
   - Set `created_at` to the registration timestamp.

2. **Update Process**:
   - Set `updated_by` to the updater's user ID.
   - Set `updated_at` to the update timestamp.

### Validations
- Confirmed proper settings of `created_by` and `created_at` during registration.
- Verified correct updates to `updated_by` and `updated_at` during operations.
- Ensured no impact on existing functionalities.
