### PR TITLE
[small] Feature/013 エラーハンドリングとログ出力の追加対応

### DIFF
--- a/src/main/java/importApp/controller/AnalysisController.java
+++ b/src/main/java/importApp/controller/AnalysisController.java
@@ -1,14 +1,16 @@
 package importApp.controller;
 
 import importApp.client.AnalyzerApiClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @RestController
-public class AnalysisController extends BaseController{
+public class AnalysisController extends BaseController {
+
+    private static final Logger log = LoggerFactory.getLogger(AnalysisController.class);
 
     private final AnalyzerApiClient analyzerApiClient;
 
@@ -31,16 +33,12 @@ public class AnalysisController extends BaseController{
             @RequestParam String endDate,
             @RequestParam String userId
     ) {
-        try {
-            // Analyzer API にリクエストを送信
-            var result = analyzerApiClient.analyzeCategory(startDate, endDate, userId);
+        log.info("GET /analyze requested with startDate={}, endDate={}, userId={}", startDate, endDate, userId);
 
-            // 成功した場合、結果を返す
-            return ResponseEntity.ok(result);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
-        } catch (RuntimeException e) {
-            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
-        }
+        // Analyzer API にリクエストを送信
+        var result = analyzerApiClient.analyzeCategory(startDate, endDate, userId);
+
+        log.info("Analysis result successfully retrieved for userId={}", userId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/importApp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/importApp/exception/GlobalExceptionHandler.java
@@ -1,20 +1,36 @@
 package importApp.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ResponseEntity<String> handleAccessDeniedException(AccessDeniedException e) {
+        log.warn("Access denied: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
     }
-}
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("Bad request: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<String> handleRuntimeException(RuntimeException e) {
+        log.error("Unexpected runtime error occurred", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("Unexpected error: " + e.getMessage());
+    }
+}


### PR DESCRIPTION
### 概要  
以下の Controller クラスに対して、
ログ出力と例外処理の一部修正を行いました。

---

### 対応内容

- **AuthController**
  - `info`, `warn`, `error` ログの出力を追加
  - 例外時は `try-catch` でログ出力 + 500エラーを回避

- **FileUploadController**
  - ファイルが空である場合の警告ログ出力
  - 成功・失敗・例外処理に対するログ追加

- **AnalysisController**
  - try-catchを削除し、正常系のみ記述
  - エラー処理は `GlobalExceptionHandler` に委譲する構成へ変更

- **共通**
  - 各 Controller に `slf4j` Logger を導入
  - コード構造や変数名は変更せず、既存実装に沿った形で対応

###  補足  
- 今後の対応として、Service層・クライアント層（`AnalyzerApiClient`など）へのログ追加予定。
