### PR TITLE
カテゴリとサブカテゴリの追加

### DIFF
--- a/src/main/java/importApp/dto/ActivityDto.java
+++ b/src/main/java/importApp/dto/ActivityDto.java
@@ -15,14 +15,17 @@ public class ActivityDto {
     private String start;
     private String end;
     private Date date;
+    private String category;
+    private String categorySub;
 
-    public ActivityDto(Long activityId, Integer userId, String title, String contents, String start, String end) {
+    public ActivityDto(Long activityId, Integer userId, String title, String contents, String start, String end, String category, String categorySub) {
         this.activityId = activityId;
         this.userId = userId;
         this.title = title;
         this.contents = contents;
         this.start = start;
         this.end = end;
-        this.date = date;
+        this.category = category;
+        this.categorySub = categorySub;
     }
 }

--- a/src/main/java/importApp/entity/ActivityEntity.java
+++ b/src/main/java/importApp/entity/ActivityEntity.java
@@ -19,6 +19,8 @@ public class ActivityEntity {
     private LocalTime end;
     private String title;
     private String contents;
+    private String category;
+    private String categorySub;
     private Long createdBy;
     private Date createdAt;
     private Long updatedBy;
@@ -32,6 +34,8 @@ public class ActivityEntity {
             LocalTime end,
             String title,
             String contents,
+            String category,
+            String categorySub,
             Long createdBy,
             Date createdAt,
             Long updatedBy,
@@ -43,6 +47,8 @@ public class ActivityEntity {
         this.end = end;
         this.title = title;
         this.contents = contents;
+        this.category = category;
+        this.categorySub = categorySub;
         this.createdBy = createdBy;
         this.createdAt = createdAt;
         this.updatedBy = updatedBy;

--- a/src/main/java/importApp/entity/ActivityGetEntity.java
+++ b/src/main/java/importApp/entity/ActivityGetEntity.java
@@ -21,6 +21,8 @@ public class ActivityGetEntity {
     private LocalTime end;
     private String title;
     private String contents;
+    private String category;
+    private String categorySub;
     private Long createdBy;
     private Date createdAt;
     private Long updatedBy;
@@ -32,6 +34,8 @@ public class ActivityGetEntity {
                           LocalTime end,
                           String title,
                           String contents,
+                          String category,
+                          String categorySub,
                           Long createdBy,
                           Long updatedBy) {
         this.userId = userId;
@@ -40,6 +44,8 @@ public class ActivityGetEntity {
         this.end= end;
         this.title = title;
         this.contents = contents;
+        this.category = category;
+        this.categorySub = categorySub;
         this.createdBy = createdBy;
         this.updatedBy = updatedBy;
     }

--- a/src/main/java/importApp/entity/PostActivityEntity.java
+++ b/src/main/java/importApp/entity/PostActivityEntity.java
@@ -17,18 +17,22 @@ public class PostActivityEntity {
     private String end;   // 終了時間（String型）
     private String title; // アクティビティ名
     private String contents; // 内容
+    private String category;
+    private String categorySub;
     private Long createdBy; // 作成者のID
     private Date createdAt; // 作成日時
     private Long updatedBy; // 更新者のID
     private Date updatedAt; // 更新日時
 
-    public PostActivityEntity(long userId, Date date, String start, String end, String title, String contents, Long createdBy, Long updatedBy) {
+    public PostActivityEntity(long userId, Date date, String start, String end, String title, String contents, String category, String categorySub, Long createdBy, Long updatedBy) {
         this.userId = userId;
         this.date = date;
         this.start = start;
         this.end = end;
         this.title = title;
         this.contents = contents;
+        this.category = category;
+        this.categorySub = categorySub;
         this.createdBy = createdBy;
         this.updatedBy = updatedBy;
     }

--- a/src/main/java/importApp/model/PostRequest.java
+++ b/src/main/java/importApp/model/PostRequest.java
@@ -1,5 +1,6 @@
 package importApp.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,5 +19,8 @@ public class PostRequest {
     private String start; // "HH:mm" 形式
     private String end;   // "HH:mm" 形式
     private String date;      // "yyyy-MM-dd" 形式
+    private String category;
+    @JsonProperty("category_sub")
+    private String categorySub;
 }
 

--- a/src/main/java/importApp/model/PutRequest.java
+++ b/src/main/java/importApp/model/PutRequest.java
@@ -1,5 +1,6 @@
 package importApp.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,4 +20,7 @@ public class PutRequest {
     private String start; // "HH:mm" 形式
     private String end;   // "HH:mm" 形式
     private String date;      // "yyyy-MM-dd" 形式
+    private String category;
+    @JsonProperty("category_sub")
+    private String categorySub;
 }

--- a/src/main/java/importApp/service/ActivityService.java
+++ b/src/main/java/importApp/service/ActivityService.java
@@ -26,6 +26,16 @@ public class ActivityService {
     private ActivityDto activityDto;
 
     public String createActivity(PostRequest request) {
+        // バリデーション
+        if (request.getCategory() == null || request.getCategory().isEmpty()) {
+            throw new IllegalArgumentException("categoryは必須です");
+        }
+        if ("その他".equals(request.getCategory()) && (request.getCategorySub() == null || request.getCategorySub().isEmpty())) {
+            throw new IllegalArgumentException("category_subは必須です");
+        }
+        if (request.getCategorySub() == null) {
+            request.setCategorySub("");
+        }
         PostActivityEntity entity = modelMapper.map(request, PostActivityEntity.class);
         // 作成者と作成日時を設定
         entity.setCreatedAt(convertToDate(LocalDateTime.now()));
@@ -39,6 +49,16 @@ public class ActivityService {
     }
 
     public boolean updateActivity(PutRequest request) {
+        // バリデーション
+        if (request.getCategory() == null || request.getCategory().isEmpty()) {
+            throw new IllegalArgumentException("categoryは必須です");
+        }
+        if ("その他".equals(request.getCategory()) && (request.getCategorySub() == null || request.getCategorySub().isEmpty())) {
+            throw new IllegalArgumentException("category_subは必須です");
+        }
+        if (request.getCategorySub() == null) {
+            request.setCategorySub("");
+        }
         PostActivityEntity entity = modelMapper.map(request, PostActivityEntity.class);
         //　更新者と更新日時を設定
         entity.setUpdatedAt(convertToDate(LocalDateTime.now()));

--- a/src/main/java/importApp/service/FileService.java
+++ b/src/main/java/importApp/service/FileService.java
@@ -94,6 +94,8 @@ public class FileService {
                         end,               // 終了時間
                         name,              // B列のアクティビティ名
                         contents,          // C列の説明
+                        "",               // category（Excelインポート時は空文字）
+                        "",               // categorySub（Excelインポート時は空文字）
                         (long) Integer.parseInt(userId),
                         convertToDate(LocalDateTime.now()), // 現在日時
                         null, // updatedByは未設定

--- a/src/main/resources/db/migration/V4__add_category_columns_to_activities.sql
+++ b/src/main/resources/db/migration/V4__add_category_columns_to_activities.sql
@@ -1,0 +1,4 @@
+-- activitiesテーブルにカテゴリ情報を追加
+ALTER TABLE activities
+  ADD COLUMN category VARCHAR(32) NOT NULL DEFAULT '',
+  ADD COLUMN category_sub VARCHAR(64) NOT NULL DEFAULT ''; 

--- a/src/main/resources/importApp/mapper/ActivityMapper.xml
+++ b/src/main/resources/importApp/mapper/ActivityMapper.xml
@@ -9,6 +9,8 @@
         <result property="end" column="end_time" />
         <result property="title" column="name" />
         <result property="contents" column="contents" />
+        <result property="category" column="category" />
+        <result property="categorySub" column="category_sub" />
         <result property="createdBy" column="created_by" />
         <result property="createdAt" column="created_at" />
         <result property="updatedBy" column="updated_by" />
@@ -16,8 +18,8 @@
     </resultMap>
 
     <insert id="save" useGeneratedKeys="true" keyProperty="activityId">
-        INSERT INTO activities (user_id, date, start_time, end_time, name, contents, created_at, created_by, updated_at, updated_by)
-        VALUES (#{userId}, #{date}, #{start}, #{end}, #{title}, #{contents}, #{createdAt}, #{createdBy}, #{updatedAt}, #{updatedBy})
+        INSERT INTO activities (user_id, date, start_time, end_time, name, contents, category, category_sub, created_at, created_by, updated_at, updated_by)
+        VALUES (#{userId}, #{date}, #{start}, #{end}, #{title}, #{contents}, #{category}, #{categorySub}, #{createdAt}, #{createdBy}, #{updatedAt}, #{updatedBy})
     </insert>
 
     <update id="updateActivity">
@@ -29,6 +31,8 @@
         end_time = #{end},
         name = #{title},
         contents = #{contents},
+        category = #{category},
+        category_sub = #{categorySub},
         updated_at = #{updatedAt},
         updated_by = #{updatedBy}
         WHERE activity_id = #{activityId}


### PR DESCRIPTION
---

## アクティビティにカテゴリ・サブカテゴリ機能を追加

### 概要
- スケジュール（アクティビティ）登録・更新APIに「カテゴリ」「サブカテゴリ」項目を追加しました。
- フロントエンドから送信されるカテゴリ情報をDBに保存し、一覧取得APIのレスポンスにもカテゴリ情報を含めるようにしました。

---

### 主な変更点

- **DBマイグレーション**
  - `activities`テーブルに`category`（VARCHAR(32)）、`category_sub`（VARCHAR(64)）カラムを追加

- **エンティティ・DTOの拡張**
  - `ActivityEntity`、`PostActivityEntity`、`ActivityGetEntity`、`ActivityDto`に`category`・`categorySub`フィールドを追加

- **リクエストDTOの拡張**
  - `PostRequest`、`PutRequest`に`category`・`categorySub`を追加
  - `@JsonProperty("category_sub")`でスネークケースにも対応

- **マッパー修正**
  - MyBatisのマッピング（Java/XML）を新カラムに対応

- **サービス層**
  - カテゴリ必須、`category`が「その他」の場合は`categorySub`も必須のバリデーションを追加
  - `categorySub`がnullの場合は空文字をセット

- **コントローラー**
  - POST/PUTのレスポンスはカテゴリ追加前のシンプルな形式に戻し、カテゴリ追加以外のロジックは維持
  - 一覧取得APIのレスポンスにカテゴリ・サブカテゴリを含めるよう修正

---

### 動作確認

- カテゴリ・サブカテゴリ付きでアクティビティの登録・更新・取得が可能
- バリデーションエラー時は適切なエラーメッセージを返却
- 既存の登録・更新・取得APIの挙動はカテゴリ追加前と同等

---

### 補足

- フロントエンドからは`category_sub`（スネークケース）で送信可能
- 既存データの`category`・`category_sub`は空文字で初期化されます

---