### PR TITLE
Fix logback configuration for production deployment

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,18 +39,3 @@ gemini:
     key: dummy_gemini_key
     url: "https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent"
 
-# ログ設定
-logging:
-  level:
-    importApp: INFO
-    org.springframework.web: WARN
-    org.hibernate: WARN
-    com.mysql: WARN
-    root: INFO
-  file:
-    path: logs
-    name: logs/application.log
-  logback:
-    rollingpolicy:
-      max-file-size: 10MB
-      max-history: 30

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -15,7 +15,7 @@
             <encoder>
                 <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
             </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                 <fileNamePattern>logs/application.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
                 <maxFileSize>10MB</maxFileSize>
                 <maxHistory>30</maxHistory>
@@ -34,7 +34,7 @@
             <encoder>
                 <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
             </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                 <fileNamePattern>logs/error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
                 <maxFileSize>10MB</maxFileSize>
                 <maxHistory>30</maxHistory>


### PR DESCRIPTION
- Changed rollingPolicy from TimeBasedRollingPolicy to SizeAndTimeBasedRollingPolicy
- Removed duplicate logging configuration from application-prod.yml
- This resolves the 502 error in production environment caused by invalid logback config

🤖 Generated with [Claude Code](https://claude.ai/code)