### PR TITLE
feat: ユーザー退会機能と設定ページAPI実装 (v0.4.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'importApp'
-version = '0.2.0'
+version = '0.4.0'
 
 java {
 	sourceCompatibility = '11'

--- a/src/main/java/importApp/entity/UserEntity.java
+++ b/src/main/java/importApp/entity/UserEntity.java
@@ -16,6 +16,7 @@ public class UserEntity {
 
     @NotBlank
     @Size(min = 3, max = 50)
+    @Column(name = "user_name")
     private String username;
 
     @NotBlank
@@ -43,12 +44,16 @@ public class UserEntity {
     
     @Column(name = "ai_monthly_limit")
     private Integer aiMonthlyLimit = 50;
+    
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
 
     public UserEntity() {
         this.provider = AuthProvider.LOCAL;
         this.isEmailVerified = false;
         this.aiDailyLimit = 5;
         this.aiMonthlyLimit = 50;
+        this.isDeleted = false;
     }
     
     // Getters for AI limits

--- a/src/main/java/importApp/model/UserResponse.java
+++ b/src/main/java/importApp/model/UserResponse.java
@@ -4,11 +4,21 @@ import lombok.Data;
 @Data // Lombokを使用してゲッターやセッターを自動生成
 public class UserResponse {
     private Long user_id;         // ユーザーID
-    private String username; // ユーザー名
+    private String username;      // ユーザー名
+    private String email;         // メールアドレス
+    private String profileImageUrl; // プロフィール画像URL
 
-    // コンストラクタ
+    // 既存のコンストラクタ（後方互換性のため）
     public UserResponse(Long id, String username) {
         this.user_id = id;
         this.username = username;
+    }
+    
+    // 設定ページ用のコンストラクタ
+    public UserResponse(Long user_id, String username, String email, String profileImageUrl) {
+        this.user_id = user_id;
+        this.username = username;
+        this.email = email;
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/resources/importApp/mapper/UserMapper.xml
+++ b/src/main/resources/importApp/mapper/UserMapper.xml
@@ -10,19 +10,36 @@
     </insert>
 
     <select id="findByEmail" resultType="importApp.entity.UserEntity">
-        SELECT * FROM users WHERE email = #{email}
+        SELECT * FROM users 
+        WHERE email = #{email} 
+        AND is_deleted = false
     </select>
 
     <select id="findByUsername" resultType="importApp.entity.UserEntity">
-        SELECT * FROM users WHERE user_name = #{username}
+        SELECT * FROM users 
+        WHERE user_name = #{username} 
+        AND is_deleted = false
     </select>
 
     <select id="findById" resultType="importApp.entity.UserEntity">
-        SELECT * FROM users WHERE user_id = #{id}
+        <!-- 
+        注意：MyBatisのmap-underscore-to-camel-caseが効かないため、明示的にエイリアスを指定しています
+        本来はSELECT *で動くべきですが、user_name -> username のマッピングが自動で行われないため冗長な記述になっています
+        TODO: 将来的にResultMapまたはフィールド名の統一を検討
+        -->
+        SELECT user_id,user_name as username, email, password, provider, google_id as googleId, 
+               profile_image_url as profileImageUrl, is_email_verified as isEmailVerified, 
+               ai_daily_limit as aiDailyLimit, ai_monthly_limit as aiMonthlyLimit, is_deleted as isDeleted
+        FROM users 
+        WHERE user_id = #{id} 
+        AND is_deleted = false
     </select>
 
     <update id="markUserAsDeleted">
-        UPDATE users SET is_deleted = true WHERE user_id = #{id}
+        UPDATE users 
+        SET is_deleted = true 
+        WHERE user_id = #{id} 
+        AND is_deleted = false
     </update>
 
     <update id="updatePassword">
@@ -34,6 +51,7 @@
         WHERE google_id = #{googleId} 
         AND provider = 'GOOGLE'
         AND user_id IS NOT NULL
+        AND is_deleted = false
     </select>
     
     <update id="updateUser" parameterType="importApp.entity.UserEntity">


### PR DESCRIPTION
## 概要
ユーザー退会機能と設定ページ用のAPIを実装しました。

## 実装内容
### 1. 退会処理API
- `DELETE /api/v1/auth/withdraw` エンドポイントを追加
- 論理削除（is_deletedフラグ）により退会ユーザーのデータを保持
- 退会後はログイン不可、同じメールアドレスで再登録可能

### 2. ユーザー情報取得API
- `GET /api/v1/auth/user` エンドポイントを追加
- 設定ページで表示するユーザー情報（ID、ユーザー名、メール、プロフィール画像）を返却
- JWTトークンによる認証が必要

### 3. データベース対応
- 全てのユーザー検索クエリに`is_deleted = false`条件を追加
- 削除ユーザーが検索結果に含まれないよう制御

### 4. その他
- API仕様書（API_SPEC.md）を追加
- MyBatisマッピング問題の解決（user_name → username）
- バージョンを0.2.0から0.3.0へアップデート

## テスト確認項目
- [x] ユーザー退会が正常に動作すること
- [x] 退会後にログインできないこと
- [x] ユーザー情報取得APIが正しい情報を返すこと
- [x] nullのプロフィール画像が正しく処理されること

## 注意事項
- UserMapper.xmlに冗長な記述があります（TODO: ResultMap導入を検討）
- 退会ユーザーの復旧は手動対応（DB直接操作）となります

🤖 Generated with [Claude Code](https://claude.ai/code)